### PR TITLE
Skip deploy on docs-only pushes

### DIFF
--- a/.github/workflows/master_fishingmap.yml
+++ b/.github/workflows/master_fishingmap.yml
@@ -7,6 +7,14 @@ on:
   push:
     branches:
       - master
+    # Docs and agent config never reach the build output, so a push touching
+    # only those would otherwise rebuild and redeploy byte-identical code.
+    # The filter looks at the whole push: a commit mixing docs with source
+    # still deploys. `.github/workflows/**` is deliberately NOT ignored — a
+    # change to this file should exercise it.
+    paths-ignore:
+      - '**/*.md'
+      - '.claude/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The deploy workflow had no path filter, so every push to `master` ran the full build and redeployed byte-identical code even when the commit only touched documentation. The recent `AGENTS.md` consolidation did exactly that in both repos.

Adds `paths-ignore` for Markdown and `.claude/` agent config — neither reaches the build output.

Notes on the filter:

- It evaluates the **whole push**, not each file: a commit mixing docs with source still deploys.
- `.github/workflows/**` is deliberately *not* ignored, so a change to this file still exercises it. That means merging this PR will itself trigger a deploy — the filter takes effect from the next push onward.
- `workflow_dispatch` is unaffected, so the manual run button stays available.

Neither repo uses branch protection, so there's no risk of a skipped run leaving a required status check pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)